### PR TITLE
Fix writing buffer larger than Bufsize

### DIFF
--- a/internal/tsh/tsh.go
+++ b/internal/tsh/tsh.go
@@ -10,6 +10,7 @@ import (
 
 	"tsh-go/internal/constants"
 	"tsh-go/internal/pel"
+	"tsh-go/internal/utils"
 
 	"github.com/schollz/progressbar/v3"
 	"golang.org/x/crypto/ssh/terminal"
@@ -138,7 +139,7 @@ func handleGetFile(layer *pel.PktEncLayer, srcfile, dstdir string) {
 		progressbar.OptionSetDescription("Downloading"),
 		progressbar.OptionSpinnerType(22),
 	)
-	io.CopyBuffer(io.MultiWriter(f, bar), layer, buffer)
+	utils.CopyBuffer(io.MultiWriter(f, bar), layer, buffer)
 	fmt.Print("\nDone.\n")
 }
 
@@ -169,7 +170,7 @@ func handlePutFile(layer *pel.PktEncLayer, srcfile, dstdir string) {
 		progressbar.OptionShowCount(),
 		progressbar.OptionSetDescription("Uploading"),
 	)
-	io.CopyBuffer(io.MultiWriter(layer, bar), f, buffer)
+	utils.CopyBuffer(io.MultiWriter(layer, bar), f, buffer)
 	fmt.Print("\nDone.\n")
 }
 
@@ -212,8 +213,8 @@ func handleRunShell(layer *pel.PktEncLayer, command string) {
 	buffer := make([]byte, constants.Bufsize)
 	buffer2 := make([]byte, constants.Bufsize)
 	go func() {
-		_, _ = io.CopyBuffer(os.Stdout, layer, buffer)
+		_, _ = utils.CopyBuffer(os.Stdout, layer, buffer)
 		layer.Close()
 	}()
-	_, _ = io.CopyBuffer(layer, os.Stdin, buffer2)
+	_, _ = utils.CopyBuffer(layer, os.Stdin, buffer2)
 }

--- a/internal/tshd/tshd.go
+++ b/internal/tshd/tshd.go
@@ -3,7 +3,6 @@ package tshd
 import (
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -14,6 +13,7 @@ import (
 	"tsh-go/internal/constants"
 	"tsh-go/internal/pel"
 	"tsh-go/internal/pty"
+	"tsh-go/internal/utils"
 )
 
 func RunInBackground() {
@@ -112,7 +112,7 @@ func handleGetFile(layer *pel.PktEncLayer) {
 		return
 	}
 	defer f.Close()
-	io.CopyBuffer(layer, f, buffer)
+	utils.CopyBuffer(layer, f, buffer)
 }
 
 func handlePutFile(layer *pel.PktEncLayer) {
@@ -127,7 +127,7 @@ func handlePutFile(layer *pel.PktEncLayer) {
 		return
 	}
 	defer f.Close()
-	io.CopyBuffer(f, layer, buffer)
+	utils.CopyBuffer(f, layer, buffer)
 	layer.Close()
 }
 
@@ -160,8 +160,8 @@ func handleRunShell(layer *pel.PktEncLayer) {
 	}
 	defer tp.Close()
 	go func() {
-		io.CopyBuffer(tp.StdIn(), layer, buffer)
+		utils.CopyBuffer(tp.StdIn(), layer, buffer)
 		tp.Close()
 	}()
-	io.CopyBuffer(layer, tp.StdOut(), buffer2)
+	utils.CopyBuffer(layer, tp.StdOut(), buffer2)
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"errors"
+	"io"
+)
+
+var errInvalidWrite = errors.New("invalid write result")
+
+func CopyBuffer(dst io.Writer, src io.Reader, buf []byte) (written int64, err error) {
+	// copied from https://cs.opensource.google/go/go/+/refs/tags/go1.23.0:src/io/io.go;l=407;drc=beea7c1ba6a93c2a2991e79936ac4050bae851c4
+	// but this version ALWAYS use the provided buffer
+	// which guarantees that it will not try to Read or Write more than the buffer size
+	for {
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			nw, ew := dst.Write(buf[0:nr])
+			if nw < 0 || nr < nw {
+				nw = 0
+				if ew == nil {
+					ew = errInvalidWrite
+				}
+			}
+			written += int64(nw)
+			if ew != nil {
+				err = ew
+				break
+			}
+			if nr != nw {
+				err = io.ErrShortWrite
+				break
+			}
+		}
+		if er != nil {
+			if er != io.EOF {
+				err = er
+			}
+			break
+		}
+	}
+	return written, err
+}


### PR DESCRIPTION
目前的版本因為用了 `io.CopyBuffer` 導致它有機會用超過 `constants.Bufsize` 的 buffer 去呼叫 `pel.Write`，導致它可能在傳輸大檔案時失敗，或是在 cat 大檔案時隨機斷線

Demo: https://asciinema.org/a/tQwTp29omfvv39BKVHsII35uG
